### PR TITLE
Log result at the end of the handleEvent(..) method

### DIFF
--- a/src/main/java/com/unblu/uneedswork/service/GitLabService.java
+++ b/src/main/java/com/unblu/uneedswork/service/GitLabService.java
@@ -85,6 +85,8 @@ public class GitLabService {
 					gitlabEventUUID, projectId, noteId, noteAuthorId, userName, mrIid);
 		}
 
+		Log.infof("GitlabEvent: '%s' | Finished handling event with result %s",
+				gitlabEventUUID, result);
 		return result;
 	}
 


### PR DESCRIPTION
Logging the result is interesting to understand how the bot reacted to a comment event (when the non blocking endpoint is used)