### PR TITLE
Do not report an error for the health endpoints

### DIFF
--- a/src/main/java/com/unblu/uneedswork/service/NoteEventController.java
+++ b/src/main/java/com/unblu/uneedswork/service/NoteEventController.java
@@ -60,7 +60,7 @@ public class NoteEventController {
 	@Route(path = "/*", order = 2)
 	public void other(@Header("X-Gitlab-Event-UUID") String gitlabEventUUID, RoutingContext rc) {
 		String path = rc.request().path();
-		if (path.equals("/q/health/live") || path.equals("/q/health/ready")) {
+		if (path.startsWith("/q/health")) {
 			// the module 'quarkus-smallrye-health' will answer:
 			rc.next();
 		} else {

--- a/src/test/java/com/unblu/uneedswork/UNeedsWorkTest.java
+++ b/src/test/java/com/unblu/uneedswork/UNeedsWorkTest.java
@@ -222,6 +222,40 @@ class UNeedsWorkTest {
 		verifyRequests(0);
 	}
 
+	@Test
+	void testHealthLive() throws Exception {
+		//make sure we get an answer from the 'quarkus-smallrye-health' module
+		given().when()
+				.get("/q/health/live")
+				.then()
+				.statusCode(Response.Status.OK.getStatusCode())
+				.body("status", notNullValue())
+				.body("checks", notNullValue())
+				.body("gitlab_event_uuid", nullValue())
+				.body("build_commit", nullValue())
+				.body("build_timestamp", nullValue())
+				.body("needs_work_note_error", nullValue());
+
+		verifyRequests(0);
+	}
+
+	@Test
+	void testHealthReady() throws Exception {
+		//make sure we get an answer from the 'quarkus-smallrye-health' module
+		given().when()
+				.post("/q/health/ready")
+				.then()
+				.statusCode(Response.Status.OK.getStatusCode())
+				.body("status", notNullValue())
+				.body("checks", notNullValue())
+				.body("gitlab_event_uuid", nullValue())
+				.body("build_commit", nullValue())
+				.body("build_timestamp", nullValue())
+				.body("needs_work_note_error", nullValue());
+
+		verifyRequests(0);
+	}
+
 	private void verifyRequests(int expectedRequestNumber) throws InterruptedException {
 		List<ServeEvent> allServeEvents = waitForRequests(expectedRequestNumber);
 


### PR DESCRIPTION
The endpoint that catches all the requests is catching the default health check endpoints (`/q/health/live` and `/q/health/ready`)  that are configured with the built-in extension `io.quarkus:quarkus-smallrye-health`.

With this change, in case of those 2 endpoints we use `next()` to delegate to the next endpoint handler.